### PR TITLE
Fix Cache Time

### DIFF
--- a/src/calendar/calendar.service.ts
+++ b/src/calendar/calendar.service.ts
@@ -54,7 +54,7 @@ export class CalendarService {
           };
         }),
       });
-      await this.cacheManager.set('calendar', calendar.toJSON(), 7200);
+      await this.cacheManager.set('calendar', calendar.toJSON(), 7200 * 1000);
       return calendar;
     }
   }


### PR DESCRIPTION
The cache manager used to use seconds, now it uses milliseconds.